### PR TITLE
fix(udm-hook): use new UDM hook API

### DIFF
--- a/univention-openvpn/univention-openvpn.py
+++ b/univention-openvpn/univention-openvpn.py
@@ -1,94 +1,20 @@
 from univention.admin.hook import simpleHook
 
+
 class univentionOpenVpn(simpleHook):
-	type = 'univentionOpenVpn'
-	delimiter = ':'
-	ldapAttribute = 'univentionOpenvpnUserAddress'
-	udmAtribute = 'openvpnuseraddress'
 
-	def __convert(self, obj):
+    @staticmethod
+    def unmap(value, encoding=()):
+        """
+        >>> univentionOpenVpn.unmap([b'uid=join-backup,cn=users,dc=w2k12,dc=test:10.200.7.66', b'uid=Administrator,cn=users,dc=w2k12,dc=test:10.200.7.11'])
+        [['uid=join-backup,cn=users,dc=w2k12,dc=test', '10.200.7.66'], ['uid=Administrator,cn=users,dc=w2k12,dc=test', '10.200.7.11']]
+        """
+        return [x.decode(*encoding).split(':', 1) for x in value]
 
-		# map
-		# [['uid=join-backup,cn=users,dc=w2k12,dc=test', '10.200.7.66'], ['uid=Administrator,cn=users,dc=w2k12,dc=test', '10.200.7.11']]
-		# to
-		# ['uid=join-backup,cn=users,dc=w2k12,dc=test: 10.200.7.66', 'uid=Administrator,cn=users,dc=w2k12,dc=test: 10.200.7.11']
-		# in openvpnuseraddress
-		changed = False
-		new = []
-		if type(obj) == type([]) and len(obj) >= 1:
-			for i in obj:
-				if type(i) == type([]) and len(i) == 2:
-					new.append(self.delimiter.join(i))
-					changed = True
-				else:
-					new.append(i)
-		if changed:
-			return new
-
-		return obj
-
-
-	def __mapOpenVpnUserAddress(self, module, ml):
-
-		newMl = []
-		mlChanged = False
-		if module.hasChanged(self.udmAtribute):
-			for i in ml:
-				if len(i) > 1 and i[0] == self.ldapAttribute:
-					if len(i) == 3:
-						old = i[1]
-						new = i[2]
-					else:
-						old = ''
-						new = i [1]
-					old = self.__convert(old)
-					new = self.__convert(new)
-					newMl.append((self.ldapAttribute, old, new))
-					mlChanged = True
-				else:
-					newMl.append(i)
-		if mlChanged:
-			return newMl
-
-		return ml
-
-	def hook_ldap_post_modify(self, module):
-		pass
-
-	def hook_open(self, module):
-
-		# map
-		# ['uid=join-backup,cn=users,dc=w2k12,dc=test: 10.200.7.66', 'uid=Administrator,cn=users,dc=w2k12,dc=test: 10.200.7.11']
-		# to
-		# [['uid=join-backup,cn=users,dc=w2k12,dc=test', '10.200.7.66'], ['uid=Administrator,cn=users,dc=w2k12,dc=test', '10.200.7.11']]
-		# in openvpnuseraddress
-		if module.get(self.udmAtribute):
-			if type(module[self.udmAtribute]) == type([]) and len(module[self.udmAtribute]) >= 1:
-				newValue = []
-				for i in module[self.udmAtribute]:
-					if type(i) == type('') and self.delimiter in i:
-						newValue.append(i.split(self.delimiter, 1))
-					else:
-						newValue.append(i)
-				module[self.udmAtribute] = newValue
-		pass
-
-	def hook_ldap_pre_create(self, module):
-		pass
-
-	def hook_ldap_addlist(self, module, al=[]):
-		al = self.__mapOpenVpnUserAddress(module, al)
-		return al
-
-	def hook_ldap_post_create(self, module):
-		pass
-
-	def hook_ldap_modlist(self, module, ml=[]):
-		ml = self.__mapOpenVpnUserAddress(module, ml)
-		return ml
-
-	def hook_ldap_pre_remove(self, module):
-		pass
-
-	def hook_ldap_post_remove(self, module):
-		pass
+    @staticmethod
+    def map(value, encoding=()):
+        """
+        >>> univentionOpenVpn.map([['uid=join-backup,cn=users,dc=w2k12,dc=test', '10.200.7.66'], ['uid=Administrator,cn=users,dc=w2k12,dc=test', '10.200.7.11']])
+        [b'uid=join-backup,cn=users,dc=w2k12,dc=test:10.200.7.66', b'uid=Administrator,cn=users,dc=w2k12,dc=test:10.200.7.11']
+        """
+        return [':'.join(x).encode(*encoding) for x in value]


### PR DESCRIPTION
as of UCS 5.2-5-errata416 a new hook API is added which simplifies this a lot.

https://docs.software-univention.de/ucs-python-api/univention.admin.html#univention.admin.hook.simpleHook.map

**WARNING**: only apply if all systems in the domain are ensure to have [UCS 5.2-5-errata416](https://errata.software-univention.de/#/?erratum=5.2x416)

TODO: We can keep the old file and register this in the joinscript for older versions, and install that for newer versions.